### PR TITLE
fix multiline comments and rename scoped-properties to settings

### DIFF
--- a/settings/language-scala.cson
+++ b/settings/language-scala.cson
@@ -1,8 +1,8 @@
-'.source':
+'.source.scala':
   'editor':
     'increaseIndentPattern': '(^.*(\\{[^}]*|\\([^)]*)$|^.*\\=\\s*$)'
     'decreaseIndentPattern': '^\\s*(\\}|\\))'
-    'commentStart': '//'
+    'commentStart': '// '
 '.keyword.other.documentation.scaladoc.scala':
   'editor':
     'completions': [


### PR DESCRIPTION
For me, multiline comments were completely broken:

![scala-comments](https://cloud.githubusercontent.com/assets/2963448/7016159/2af9f00c-dcad-11e4-9c31-2e433e0430a7.gif)

It was a relatively easy fix. I also renamed scoped-properties to settings, because that seems to be the format of grammars now. Everything looks like it works on my end:

![scala-comments-fixed](https://cloud.githubusercontent.com/assets/2963448/7033893/8ad84df4-dd4b-11e4-8194-015585371c7d.gif)
